### PR TITLE
Fix Typo in 7-seq2seq-translation.ipynb

### DIFF
--- a/7-seq2seq-translation.ipynb
+++ b/7-seq2seq-translation.ipynb
@@ -718,7 +718,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import fastText as ft"
+    "import fasttext as ft"
    ]
   },
   {


### PR DESCRIPTION
Initially:
```python
import fastText as ft
```
Fixed:
```python
import fasttext as ft
```