### PR TITLE
Fixing typos on "algebra" word

### DIFF
--- a/2b-odds-and-ends.ipynb
+++ b/2b-odds-and-ends.ipynb
@@ -202,9 +202,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The 3Blue 1Brown [Essence of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab) videos are fantastic.  They give a much more visual & geometric perspective on linear algreba than how it is typically taught.  These videos are a great resource if you are a linear algebra beginner, or feel uncomfortable or rusty with the material.\n",
+    "The 3Blue 1Brown [Essence of Linear Algebra](https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab) videos are fantastic.  They give a much more visual & geometric perspective on linear algebra than how it is typically taught.  These videos are a great resource if you are a linear algebra beginner, or feel uncomfortable or rusty with the material.\n",
     "\n",
-    "Even if you are a linear algrebra pro, I still recommend these videos for a new perspective, and they are very well made."
+    "Even if you are a linear algebra pro, I still recommend these videos for a new perspective, and they are very well made."
    ]
   },
   {


### PR DESCRIPTION
I detected two typos on the Jupyter Notebook, both in word "algebra". This PR fixes them.