### PR TITLE
Fixed spacy download model command

### DIFF
--- a/2-svd-nmf-topic-modeling.ipynb
+++ b/2-svd-nmf-topic-modeling.ipynb
@@ -549,7 +549,7 @@
     "\n",
     "You will then need to download the English model:\n",
     "```\n",
-    "spacy -m download en_core_web_sm\n",
+    "python -m spacy download en_core_web_sm\n",
     "```"
    ]
   },


### PR DESCRIPTION
the command should be `python -m spacy download en_core_web_sm`

source: https://spacy.io/models#quickstart