### PR TITLE
Fixed file path for loading wikitext103 itos pkl.

### DIFF
--- a/5-nn-imdb.ipynb
+++ b/5-nn-imdb.ipynb
@@ -736,7 +736,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wiki_itos = pickle.load(open(Config().model_path()/'wt103-1/itos_wt103.pkl', 'rb'))"
+    "wiki_itos = pickle.load(open(Config().model_path()/'wt103-fwd/itos_wt103.pkl', 'rb'))"
    ]
   },
   {


### PR DESCRIPTION
The current file path causes a "File not found" exception, as the folder structure is incorrect in the hard-coded notebook path.