### PR TITLE
fix: edit minor typo

### DIFF
--- a/4-regex.ipynb
+++ b/4-regex.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "101 Howard\n",
     "\n",
-    "Some of the phone numbers have different formats (hyphens, no hyphens).  Also, there are some errors in the data-- 101 Howard isn't a phon number!  How can we find all the phone numbers?\n",
+    "Some of the phone numbers have different formats (hyphens, no hyphens).  Also, there are some errors in the data-- 101 Howard isn't a phone number!  How can we find all the phone numbers?\n",
     "\n",
     "#### 2. Creating our own tokens\n",
     "\n",


### PR DESCRIPTION
Corrected a minor typo. Looks like "phone" was misspelled as "phon" in one of the lines.