### PR TITLE
Update 2-svd-nmf-topic-modeling.ipynb

### DIFF
--- a/2-svd-nmf-topic-modeling.ipynb
+++ b/2-svd-nmf-topic-modeling.ipynb
@@ -569,7 +569,9 @@
    "outputs": [],
    "source": [
     "from spacy.lemmatizer import Lemmatizer\n",
-    "lemmatizer = Lemmatizer()"
+    "from spacy.lookups import Lookups\n",
+    "lookups = Lookups()\n",
+    "lemmatizer = Lemmatizer(lookups)"
    ]
   },
   {


### PR DESCRIPTION
`lemmatizer = Lemmatizer()` currently produces the following error:
`TypeError: __init__() missing 1 required positional argument: 'lookups'`

This just creates a Lookups object and passes it to the lemmatizer so that it can be initialized. 