### PR TITLE
spacy: As of v2.2, the lemmatizer is initialized with a Lookups

### DIFF
--- a/2-svd-nmf-topic-modeling.ipynb
+++ b/2-svd-nmf-topic-modeling.ipynb
@@ -569,7 +569,10 @@
    "outputs": [],
    "source": [
     "from spacy.lemmatizer import Lemmatizer\n",
-    "lemmatizer = Lemmatizer()"
+    "from spacy.lookups import Lookups\n",
+    "lookups = Lookups()\n",
+    "lookups.add_table(\"lemma_rules\", {\"noun\": [[\"s\", \"\"]]})\n",
+    "lemmatizer = Lemmatizer(lookups)"
    ]
   },
   {


### PR DESCRIPTION
* Deprecation note
As of v2.2, the lemmatizer is initialized with a Lookups object containing tables for the different components. This makes it easier for spaCy to share and serialize rules and lookup tables via the Vocab and allows users to modify lemmatizer data at runtime by updating nlp.vocab.lookups.

