### PR TITLE
Spacy 2.2 lookuptable is needed in Lemmatizer()

### DIFF
--- a/2-svd-nmf-topic-modeling.ipynb
+++ b/2-svd-nmf-topic-modeling.ipynb
@@ -569,7 +569,9 @@
    "outputs": [],
    "source": [
     "from spacy.lemmatizer import Lemmatizer\n",
-    "lemmatizer = Lemmatizer()"
+    "from spacy.lookups import Lookups\n",
+    "lookups = Lookups()\n",
+    "lemmatizer = Lemmatizer(lookups)\n",
    ]
   },
   {


### PR DESCRIPTION
As of Spacy v2.2, the Lemmatizer is initialized with an instance of Lookups containing the lemmatization tables. See the docs for details: https://spacy.io/api/lemmatizer#init