### PR TITLE
Changed fastText import statement

### DIFF
--- a/7-seq2seq-translation.ipynb
+++ b/7-seq2seq-translation.ipynb
@@ -718,7 +718,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import fastText as ft"
+    "import fasttext as ft"
    ]
   },
   {


### PR DESCRIPTION
I needed to `import fasttext` rather than `fastText` in for my interpreter to find the pip-installed module correctly.