### PR TITLE
Remove -m flag from en_core_web_sm download

### DIFF
--- a/2-svd-nmf-topic-modeling.ipynb
+++ b/2-svd-nmf-topic-modeling.ipynb
@@ -549,7 +549,7 @@
     "\n",
     "You will then need to download the English model:\n",
     "```\n",
-    "spacy -m download en_core_web_sm\n",
+    "spacy download en_core_web_sm\n",
     "```"
    ]
   },


### PR DESCRIPTION
The `-m` flag in `spacy -m download en_core_web_sm` was likely there due to an alternative installation method `python -m spacy download en_core_web_sm`.