### PR TITLE
Update 2-svd-nmf-topic-modeling.ipynb

### DIFF
--- a/2-svd-nmf-topic-modeling.ipynb
+++ b/2-svd-nmf-topic-modeling.ipynb
@@ -350,9 +350,9 @@
     }
    ],
    "source": [
-    "from sklearn.feature_extraction import stop_words\n",
+    "from sklearn.feature_extraction import _stop_words\n",
     "\n",
-    "sorted(list(stop_words.ENGLISH_STOP_WORDS))[:20]"
+    "sorted(list(_stop_words.ENGLISH_STOP_WORDS))[:20]"
    ]
   },
   {


### PR DESCRIPTION
In the latest update we have to use _stop_words instead of stop _words.